### PR TITLE
fix: chain promise on stream close

### DIFF
--- a/packages/binary-install/index.js
+++ b/packages/binary-install/index.js
@@ -62,7 +62,12 @@ class Binary {
 
     return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
       .then(res => {
-        res.data.pipe(tar.x({ strip: 1, C: this.installDirectory }));
+        return new Promise((resolve, reject) => {
+	  const sink = tar.x({ strip: 1, C: this.installDirectory });
+          res.data.pipe(sink);
+	  sink.on('finish', () => resolve());
+	  sink.on('error', err => reject(err));
+        });
       })
       .then(() => {
         console.log(`${this.name} has been installed!`);


### PR DESCRIPTION
Currently, we stream data from axios through tar, but chain a return
value from `then` immediately after creating the stream rather than
after the stream completes.

This commit chains a promise that resolves when the stream finishes
either successfully or with error.

The use case is a consumer of `binary-install` chaining the promise
returned from `install`:

```javascript
getBinary().install()
  .then(linkBinaryIntoBin)
```

With the current implementation, the chained code does not see the
downloaded file as it is still being written, causing errors like:

```
[Error: ENOENT: no such file or directory, link '/home/foo/workspace/bar/baz/node_modules/binary-install/bin/quux' -> '/home/foo/workspace/bar/haz/node_modules/.bin/quux'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'link',
  path: '/home/foo/workspace/bar/baz/node_modules/binary-install/bin/quux',
  dest: '/home/foo/workspace/bar/haz/node_modules/.bin/quux'
}
```

With this commit, we can chain additional event handlers that run after
`binary-install` has completed execution.