### PR TITLE
Fix log suppression

### DIFF
--- a/packages/binary-install/index.js
+++ b/packages/binary-install/index.js
@@ -71,7 +71,7 @@ class Binary {
 
     mkdirSync(this.installDirectory, { recursive: true });
 
-    if (suppressLogs) {
+    if (!suppressLogs) {
       console.error(`Downloading release from ${this.url}`);
     }
 
@@ -86,7 +86,7 @@ class Binary {
         });
       })
       .then(() => {
-        if (suppressLogs) {
+        if (!suppressLogs) {
           console.error(`${this.name} has been installed!`);
         }
       })
@@ -97,7 +97,7 @@ class Binary {
 
   run(fetchOptions) {
     if (!this.exists()) {
-      this.install(fetchOptions, true)
+      this.install(fetchOptions, true);
     }
 
     const [, , ...args] = process.argv;


### PR DESCRIPTION
This PR fixes some instances of logs not being suppressed.

The usage of the `suppressLogs` flag was actually inverted, with `suppressLogs = true` causing the logs to be written and `suppressLogs = false` causing the logs to be suppressed.