### PR TITLE
Update example platforms with Apple silicon support

### DIFF
--- a/packages/binary-install-example/binary.js
+++ b/packages/binary-install-example/binary.js
@@ -35,6 +35,12 @@ const supportedPlatforms = [
     ARCHITECTURE: "x64",
     RUST_TARGET: "x86_64-apple-darwin",
     BINARY_NAME: "binary-install-example"
+  },
+  {
+    TYPE: "Darwin",
+    ARCHITECTURE: "arm64",
+    RUST_TARGET: "x86_64-apple-darwin",
+    BINARY_NAME: "binary-install-example"
   }
 ];
 

--- a/packages/binary-install/index.js
+++ b/packages/binary-install/index.js
@@ -97,7 +97,7 @@ class Binary {
 
   run(fetchOptions) {
     if (!this.exists()) {
-      this.install(fetchOptions, true)
+      this.install(fetchOptions, true);
     }
 
     const [, , ...args] = process.argv;


### PR DESCRIPTION
This PR updates the supported platforms in the `binary-install-example` to include support for Apple silicon.

Since we don't currently build binaries for Apple silicon we're just using the `x86_64-apple-darwin` target triple, which will then get run through Rosetta 2. This is the same thing that Rover [currently does](https://github.com/apollographql/rover/blob/a0b0ca86a6d204ab928e9b5f83c81119cac0eb7b/installers/npm/binary.js#L34-L39).