### PR TITLE
release: v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# `binary-install` changelog
+
+## v1.1.0
+
+### Features
+
+- Adds an optional third argument to `new Binary` to configure the installation directory - @wighawag, PR #29
+
+  Example: `new Binary("my-binary", "https://example.com/my-binary.tar.gz", { "installDirectory": "/tmp/custom-dir" })`
+
+### Maintenance
+
+- Updates `binary-install-example` to download Intel binaries by default for Apple Silicon machines - @maxdeviant, PR #24
+
+- Fix log suppression configuration - @maxdeviant, PR #23
+
+  This PR makes the `suppressLogs` behavior actually respected, before it was inverted and would log messages incorrectly.
+
+- Wait for a complete install before running a binary - @wighawag, PR #28 fixes #27
+
+  Sometimes installation wouldn't complete before the binary was run, this PR rewrites the code to fully complete installation before continuing to execution.
+
+- Fix up integration tests - @EverlastingBugstopper, PR #31
+
+  This relied on overriding `installDirectory` with the new feature in this release, thanks @wighawag!
+
+## [<= v1.0.6]
+
+There are no changelog entries pre-v1.1.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3796,9 +3796,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001482",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001482.tgz",
-			"integrity": "sha512-F1ZInsg53cegyjroxLNW9DmrEQ1SuGRTO1QlpA0o2/6OpQ0gFeDRoq1yFmnr8Sakn9qwwt9DmbxHB6w167OSuQ==",
+			"version": "1.0.30001486",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
+			"integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -4968,9 +4968,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.381",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.381.tgz",
-			"integrity": "sha512-jSbS1KRmmGO6SwssmVQpCy1jENfCJT6hN36W6Dxj5HXUj59cUn6yd4gv5113mfATo6aEj/mPUTkMZmNknFXj6Q=="
+			"version": "1.4.390",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.390.tgz",
+			"integrity": "sha512-9h6KDGTynRfpM16U40uLSCxRO3diIKcXXI0mPChKls7sfkxOlCH1sgSJ14Rb00BFomQNHY/p67gaZSu5Mu8j6w=="
 		},
 		"node_modules/emittery": {
 			"version": "0.8.1",
@@ -17988,9 +17988,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001482",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001482.tgz",
-			"integrity": "sha512-F1ZInsg53cegyjroxLNW9DmrEQ1SuGRTO1QlpA0o2/6OpQ0gFeDRoq1yFmnr8Sakn9qwwt9DmbxHB6w167OSuQ=="
+			"version": "1.0.30001486",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
+			"integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg=="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -18946,9 +18946,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.381",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.381.tgz",
-			"integrity": "sha512-jSbS1KRmmGO6SwssmVQpCy1jENfCJT6hN36W6Dxj5HXUj59cUn6yd4gv5113mfATo6aEj/mPUTkMZmNknFXj6Q=="
+			"version": "1.4.390",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.390.tgz",
+			"integrity": "sha512-9h6KDGTynRfpM16U40uLSCxRO3diIKcXXI0mPChKls7sfkxOlCH1sgSJ14Rb00BFomQNHY/p67gaZSu5Mu8j6w=="
 		},
 		"emittery": {
 			"version": "0.8.1",

--- a/packages/binary-install/package.json
+++ b/packages/binary-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binary-install",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Install binary applications via npm",
   "main": "./index.js",
   "engines": {


### PR DESCRIPTION
## v1.1.0

### Features

- Adds an optional third argument to `new Binary` to configure the installation directory - @wighawag, PR #29

  Example: `new Binary("my-binary", "https://example.com/my-binary.tar.gz", { "installDirectory": "/tmp/custom-dir" })`

### Maintenance

- Updates `binary-install-example` to download Intel binaries by default for Apple Silicon machines - @maxdeviant, PR #24

- Fix log suppression configuration - @maxdeviant, PR #23

  This PR makes the `suppressLogs` behavior actually respected, before it was inverted and would log messages incorrectly.

- Wait for a complete install before running a binary - @wighawag, PR #28 fixes #27

  Sometimes installation wouldn't complete before the binary was run, this PR rewrites the code to fully complete installation before continuing to execution.

- Fix up integration tests - @EverlastingBugstopper, PR #31

  This relied on overriding `installDirectory` with the new feature in this release, thanks @wighawag!