### PR TITLE
fix: version binary installs to allow upgrades

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,28 +42,28 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.21.7",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.7.tgz",
-			"integrity": "sha512-KYMqFYTaenzMK4yUtf4EW9wc4N9ef80FsbMtkwool5zpwl4YrT1SdWYSTRcT94KO4hannogdS+LxY7L+arP3gA==",
+			"version": "7.22.3",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.3.tgz",
+			"integrity": "sha512-aNtko9OPOwVESUFp3MZfD8Uzxl7JzSeJpd7npIoxCasU37PFbAQRpKglkaKwlHOyeJdrREpo8TW8ldrkYWwvIQ==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.21.8",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.8.tgz",
-			"integrity": "sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==",
+			"version": "7.22.1",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.1.tgz",
+			"integrity": "sha512-Hkqu7J4ynysSXxmAahpN1jjRwVJ+NdpraFLIWflgjpVob3KNyK3/tIUc7Q7szed8WMp0JNa7Qtd1E9Oo22F9gA==",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.21.4",
-				"@babel/generator": "^7.21.5",
-				"@babel/helper-compilation-targets": "^7.21.5",
-				"@babel/helper-module-transforms": "^7.21.5",
-				"@babel/helpers": "^7.21.5",
-				"@babel/parser": "^7.21.8",
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.21.5",
-				"@babel/types": "^7.21.5",
+				"@babel/generator": "^7.22.0",
+				"@babel/helper-compilation-targets": "^7.22.1",
+				"@babel/helper-module-transforms": "^7.22.1",
+				"@babel/helpers": "^7.22.0",
+				"@babel/parser": "^7.22.0",
+				"@babel/template": "^7.21.9",
+				"@babel/traverse": "^7.22.1",
+				"@babel/types": "^7.22.0",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -100,11 +100,11 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.5.tgz",
-			"integrity": "sha512-SrKK/sRv8GesIW1bDagf9cCG38IOMYZusoe1dfg0D8aiUe3Amvoj1QtjTPAWcfrZFvIwlleLb0gxzQidL9w14w==",
+			"version": "7.22.3",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.3.tgz",
+			"integrity": "sha512-C17MW4wlk//ES/CJDL51kPNwl+qiBQyN7b9SKyVp11BLGFeSPoVaHrv+MNt8jwQFhQWowW88z1eeBx3pFz9v8A==",
 			"dependencies": {
-				"@babel/types": "^7.21.5",
+				"@babel/types": "^7.22.3",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
@@ -114,11 +114,11 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.21.5.tgz",
-			"integrity": "sha512-1RkbFGUKex4lvsB9yhIfWltJM5cZKUftB2eNajaDv3dCMEp49iBG0K14uH8NnX9IPux2+mK7JGEOB0jn48/J6w==",
+			"version": "7.22.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.1.tgz",
+			"integrity": "sha512-Rqx13UM3yVB5q0D/KwQ8+SPfX/+Rnsy1Lw1k/UwOC4KC6qrzIQoY3lYnBu5EHKBlEHHcj0M0W8ltPSkD8rqfsQ==",
 			"dependencies": {
-				"@babel/compat-data": "^7.21.5",
+				"@babel/compat-data": "^7.22.0",
 				"@babel/helper-validator-option": "^7.21.0",
 				"browserslist": "^4.21.3",
 				"lru-cache": "^5.1.1",
@@ -132,9 +132,9 @@
 			}
 		},
 		"node_modules/@babel/helper-environment-visitor": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.21.5.tgz",
-			"integrity": "sha512-IYl4gZ3ETsWocUWgsFZLM5i1BYx9SoemminVEXadgLBa9TdeorzgLKm8wWLA6J1N/kT3Kch8XIk1laNzYoHKvQ==",
+			"version": "7.22.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.1.tgz",
+			"integrity": "sha512-Z2tgopurB/kTbidvzeBrc2To3PUP/9i5MUe+fU6QJCQDyPwSH2oRapkLw3KGECDYSjhQZCNxEvNvZlLw8JjGwA==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -174,18 +174,18 @@
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.5.tgz",
-			"integrity": "sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==",
+			"version": "7.22.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.1.tgz",
+			"integrity": "sha512-dxAe9E7ySDGbQdCVOY/4+UcD8M9ZFqZcZhSPsPacvCG4M+9lwtDDQfI2EoaSvmf7W/8yCBkGU0m7Pvt1ru3UZw==",
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.21.5",
+				"@babel/helper-environment-visitor": "^7.22.1",
 				"@babel/helper-module-imports": "^7.21.4",
 				"@babel/helper-simple-access": "^7.21.5",
 				"@babel/helper-split-export-declaration": "^7.18.6",
 				"@babel/helper-validator-identifier": "^7.19.1",
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.21.5",
-				"@babel/types": "^7.21.5"
+				"@babel/template": "^7.21.9",
+				"@babel/traverse": "^7.22.1",
+				"@babel/types": "^7.22.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -246,13 +246,13 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.5.tgz",
-			"integrity": "sha512-BSY+JSlHxOmGsPTydUkPf1MdMQ3M81x5xGCOVgWM3G8XH77sJ292Y2oqcp0CbbgxhqBuI46iUz1tT7hqP7EfgA==",
+			"version": "7.22.3",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.3.tgz",
+			"integrity": "sha512-jBJ7jWblbgr7r6wYZHMdIqKc73ycaTcCaWRq4/2LpuPHcx7xMlZvpGQkOYc9HeSjn6rcx15CPlgVcBtZ4WZJ2w==",
 			"dependencies": {
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.21.5",
-				"@babel/types": "^7.21.5"
+				"@babel/template": "^7.21.9",
+				"@babel/traverse": "^7.22.1",
+				"@babel/types": "^7.22.3"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -272,9 +272,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.21.8",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.8.tgz",
-			"integrity": "sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==",
+			"version": "7.22.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.4.tgz",
+			"integrity": "sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -432,31 +432,31 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
-			"integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
+			"version": "7.21.9",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.21.9.tgz",
+			"integrity": "sha512-MK0X5k8NKOuWRamiEfc3KEJiHMTkGZNUjzMipqCGDDc6ijRl/B7RGSKVGncu4Ro/HdyzzY6cmoXuKI2Gffk7vQ==",
 			"dependencies": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/parser": "^7.20.7",
-				"@babel/types": "^7.20.7"
+				"@babel/code-frame": "^7.21.4",
+				"@babel/parser": "^7.21.9",
+				"@babel/types": "^7.21.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.5.tgz",
-			"integrity": "sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==",
+			"version": "7.22.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.4.tgz",
+			"integrity": "sha512-Tn1pDsjIcI+JcLKq1AVlZEr4226gpuAQTsLMorsYg9tuS/kG7nuwwJ4AB8jfQuEgb/COBwR/DqJxmoiYFu5/rQ==",
 			"dependencies": {
 				"@babel/code-frame": "^7.21.4",
-				"@babel/generator": "^7.21.5",
-				"@babel/helper-environment-visitor": "^7.21.5",
+				"@babel/generator": "^7.22.3",
+				"@babel/helper-environment-visitor": "^7.22.1",
 				"@babel/helper-function-name": "^7.21.0",
 				"@babel/helper-hoist-variables": "^7.18.6",
 				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.21.5",
-				"@babel/types": "^7.21.5",
+				"@babel/parser": "^7.22.4",
+				"@babel/types": "^7.22.4",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -486,9 +486,9 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/@babel/types": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.5.tgz",
-			"integrity": "sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==",
+			"version": "7.22.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.4.tgz",
+			"integrity": "sha512-Tx9x3UBHTTsMSW85WB2kphxYQVvrZ/t1FxD88IpSgIjiUJlCm9z+xWIDwyo1vffTwSqteqyznB8ZE9vYYk16zA==",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.21.5",
 				"@babel/helper-validator-identifier": "^7.19.1",
@@ -2828,9 +2828,9 @@
 			}
 		},
 		"node_modules/@types/babel__core": {
-			"version": "7.20.0",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
-			"integrity": "sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==",
+			"version": "7.20.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
+			"integrity": "sha512-aACu/U/omhdk15O4Nfb+fHgH/z3QsfQzpnvRZhYhThms83ZnAOZz7zZAWO7mn2yyNQaA4xTO8GLK3uqFU4bYYw==",
 			"dependencies": {
 				"@babel/parser": "^7.20.7",
 				"@babel/types": "^7.20.7",
@@ -2857,11 +2857,11 @@
 			}
 		},
 		"node_modules/@types/babel__traverse": {
-			"version": "7.18.5",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.5.tgz",
-			"integrity": "sha512-enCvTL8m/EHS/zIvJno9nE+ndYPh1/oNFzRYRmtUqJICG2VnCSBzMLW5VN2KCQU91f23tsNKR8v7VJJQMatl7Q==",
+			"version": "7.20.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.1.tgz",
+			"integrity": "sha512-MitHFXnhtgwsGZWtT68URpOvLN4EREih1u3QtQiN4VdAxWKRVvGCSvw/Qth0M0Qq3pJpnGOu5JaM/ydK7OGbqg==",
 			"dependencies": {
-				"@babel/types": "^7.3.0"
+				"@babel/types": "^7.20.7"
 			}
 		},
 		"node_modules/@types/glob": {
@@ -2927,9 +2927,9 @@
 			"dev": true
 		},
 		"node_modules/@types/prettier": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
-			"integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg=="
+			"version": "2.7.3",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+			"integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA=="
 		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.1",
@@ -3594,9 +3594,9 @@
 			"integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
 		},
 		"node_modules/browserslist": {
-			"version": "4.21.5",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
-			"integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+			"version": "4.21.7",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.7.tgz",
+			"integrity": "sha512-BauCXrQ7I2ftSqd2mvKHGo85XR0u7Ru3C/Hxsy/0TkfCtjrmAbPdzLGasmoiBxplpDXlPvdjX9u7srIMfgasNA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -3605,13 +3605,17 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001449",
-				"electron-to-chromium": "^1.4.284",
-				"node-releases": "^2.0.8",
-				"update-browserslist-db": "^1.0.10"
+				"caniuse-lite": "^1.0.30001489",
+				"electron-to-chromium": "^1.4.411",
+				"node-releases": "^2.0.12",
+				"update-browserslist-db": "^1.0.11"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -3796,9 +3800,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001486",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
-			"integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg==",
+			"version": "1.0.30001492",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz",
+			"integrity": "sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -4968,9 +4972,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.390",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.390.tgz",
-			"integrity": "sha512-9h6KDGTynRfpM16U40uLSCxRO3diIKcXXI0mPChKls7sfkxOlCH1sgSJ14Rb00BFomQNHY/p67gaZSu5Mu8j6w=="
+			"version": "1.4.417",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.417.tgz",
+			"integrity": "sha512-8rY8HdCxuSVY8wku3i/eDac4g1b4cSbruzocenrqBlzqruAZYHjQCHIjC66dLR9DXhEHTojsC4EjhZ8KmzwXqA=="
 		},
 		"node_modules/emittery": {
 			"version": "0.8.1",
@@ -9673,9 +9677,9 @@
 			}
 		},
 		"node_modules/jest-snapshot/node_modules/semver": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-			"integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+			"version": "7.5.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+			"integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -11451,9 +11455,9 @@
 			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
-			"integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
+			"integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ=="
 		},
 		"node_modules/nopt": {
 			"version": "4.0.3",
@@ -11626,9 +11630,9 @@
 			}
 		},
 		"node_modules/nwsapi": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.4.tgz",
-			"integrity": "sha512-NHj4rzRo0tQdijE9ZqAx6kYDcoRwYwSYzCA8MY3JzfxlrvEU0jhnhJT9BhqhJs7I/dKcrDm6TyulaRqZPIhN5g=="
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.5.tgz",
+			"integrity": "sha512-6xpotnECFy/og7tKSBVmUNft7J3jyXAka4XvG6AUhFWRz+Q/Ljus7znJAA3bxColfQLdS+XsjoodtJfCgeTEFQ=="
 		},
 		"node_modules/oauth-sign": {
 			"version": "0.9.0",
@@ -13860,9 +13864,9 @@
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
 		},
 		"node_modules/tar": {
-			"version": "6.1.14",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.14.tgz",
-			"integrity": "sha512-piERznXu0U7/pW7cdSn7hjqySIVTYT6F76icmFk7ptU7dDYlXTm5r9A6K04R2vU3olYgoKeo1Cg3eeu5nhftAw==",
+			"version": "6.1.15",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
+			"integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
 			"dependencies": {
 				"chownr": "^2.0.0",
 				"fs-minipass": "^2.0.0",
@@ -14947,25 +14951,25 @@
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.21.7",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.7.tgz",
-			"integrity": "sha512-KYMqFYTaenzMK4yUtf4EW9wc4N9ef80FsbMtkwool5zpwl4YrT1SdWYSTRcT94KO4hannogdS+LxY7L+arP3gA=="
+			"version": "7.22.3",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.3.tgz",
+			"integrity": "sha512-aNtko9OPOwVESUFp3MZfD8Uzxl7JzSeJpd7npIoxCasU37PFbAQRpKglkaKwlHOyeJdrREpo8TW8ldrkYWwvIQ=="
 		},
 		"@babel/core": {
-			"version": "7.21.8",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.8.tgz",
-			"integrity": "sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==",
+			"version": "7.22.1",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.1.tgz",
+			"integrity": "sha512-Hkqu7J4ynysSXxmAahpN1jjRwVJ+NdpraFLIWflgjpVob3KNyK3/tIUc7Q7szed8WMp0JNa7Qtd1E9Oo22F9gA==",
 			"requires": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.21.4",
-				"@babel/generator": "^7.21.5",
-				"@babel/helper-compilation-targets": "^7.21.5",
-				"@babel/helper-module-transforms": "^7.21.5",
-				"@babel/helpers": "^7.21.5",
-				"@babel/parser": "^7.21.8",
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.21.5",
-				"@babel/types": "^7.21.5",
+				"@babel/generator": "^7.22.0",
+				"@babel/helper-compilation-targets": "^7.22.1",
+				"@babel/helper-module-transforms": "^7.22.1",
+				"@babel/helpers": "^7.22.0",
+				"@babel/parser": "^7.22.0",
+				"@babel/template": "^7.21.9",
+				"@babel/traverse": "^7.22.1",
+				"@babel/types": "^7.22.0",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -14989,22 +14993,22 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.5.tgz",
-			"integrity": "sha512-SrKK/sRv8GesIW1bDagf9cCG38IOMYZusoe1dfg0D8aiUe3Amvoj1QtjTPAWcfrZFvIwlleLb0gxzQidL9w14w==",
+			"version": "7.22.3",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.3.tgz",
+			"integrity": "sha512-C17MW4wlk//ES/CJDL51kPNwl+qiBQyN7b9SKyVp11BLGFeSPoVaHrv+MNt8jwQFhQWowW88z1eeBx3pFz9v8A==",
 			"requires": {
-				"@babel/types": "^7.21.5",
+				"@babel/types": "^7.22.3",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.21.5.tgz",
-			"integrity": "sha512-1RkbFGUKex4lvsB9yhIfWltJM5cZKUftB2eNajaDv3dCMEp49iBG0K14uH8NnX9IPux2+mK7JGEOB0jn48/J6w==",
+			"version": "7.22.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.1.tgz",
+			"integrity": "sha512-Rqx13UM3yVB5q0D/KwQ8+SPfX/+Rnsy1Lw1k/UwOC4KC6qrzIQoY3lYnBu5EHKBlEHHcj0M0W8ltPSkD8rqfsQ==",
 			"requires": {
-				"@babel/compat-data": "^7.21.5",
+				"@babel/compat-data": "^7.22.0",
 				"@babel/helper-validator-option": "^7.21.0",
 				"browserslist": "^4.21.3",
 				"lru-cache": "^5.1.1",
@@ -15012,9 +15016,9 @@
 			}
 		},
 		"@babel/helper-environment-visitor": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.21.5.tgz",
-			"integrity": "sha512-IYl4gZ3ETsWocUWgsFZLM5i1BYx9SoemminVEXadgLBa9TdeorzgLKm8wWLA6J1N/kT3Kch8XIk1laNzYoHKvQ=="
+			"version": "7.22.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.1.tgz",
+			"integrity": "sha512-Z2tgopurB/kTbidvzeBrc2To3PUP/9i5MUe+fU6QJCQDyPwSH2oRapkLw3KGECDYSjhQZCNxEvNvZlLw8JjGwA=="
 		},
 		"@babel/helper-function-name": {
 			"version": "7.21.0",
@@ -15042,18 +15046,18 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.5.tgz",
-			"integrity": "sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==",
+			"version": "7.22.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.1.tgz",
+			"integrity": "sha512-dxAe9E7ySDGbQdCVOY/4+UcD8M9ZFqZcZhSPsPacvCG4M+9lwtDDQfI2EoaSvmf7W/8yCBkGU0m7Pvt1ru3UZw==",
 			"requires": {
-				"@babel/helper-environment-visitor": "^7.21.5",
+				"@babel/helper-environment-visitor": "^7.22.1",
 				"@babel/helper-module-imports": "^7.21.4",
 				"@babel/helper-simple-access": "^7.21.5",
 				"@babel/helper-split-export-declaration": "^7.18.6",
 				"@babel/helper-validator-identifier": "^7.19.1",
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.21.5",
-				"@babel/types": "^7.21.5"
+				"@babel/template": "^7.21.9",
+				"@babel/traverse": "^7.22.1",
+				"@babel/types": "^7.22.0"
 			}
 		},
 		"@babel/helper-plugin-utils": {
@@ -15093,13 +15097,13 @@
 			"integrity": "sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ=="
 		},
 		"@babel/helpers": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.5.tgz",
-			"integrity": "sha512-BSY+JSlHxOmGsPTydUkPf1MdMQ3M81x5xGCOVgWM3G8XH77sJ292Y2oqcp0CbbgxhqBuI46iUz1tT7hqP7EfgA==",
+			"version": "7.22.3",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.3.tgz",
+			"integrity": "sha512-jBJ7jWblbgr7r6wYZHMdIqKc73ycaTcCaWRq4/2LpuPHcx7xMlZvpGQkOYc9HeSjn6rcx15CPlgVcBtZ4WZJ2w==",
 			"requires": {
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.21.5",
-				"@babel/types": "^7.21.5"
+				"@babel/template": "^7.21.9",
+				"@babel/traverse": "^7.22.1",
+				"@babel/types": "^7.22.3"
 			}
 		},
 		"@babel/highlight": {
@@ -15113,9 +15117,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.21.8",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.8.tgz",
-			"integrity": "sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA=="
+			"version": "7.22.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.4.tgz",
+			"integrity": "sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA=="
 		},
 		"@babel/plugin-syntax-async-generators": {
 			"version": "7.8.4",
@@ -15222,28 +15226,28 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
-			"integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
+			"version": "7.21.9",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.21.9.tgz",
+			"integrity": "sha512-MK0X5k8NKOuWRamiEfc3KEJiHMTkGZNUjzMipqCGDDc6ijRl/B7RGSKVGncu4Ro/HdyzzY6cmoXuKI2Gffk7vQ==",
 			"requires": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/parser": "^7.20.7",
-				"@babel/types": "^7.20.7"
+				"@babel/code-frame": "^7.21.4",
+				"@babel/parser": "^7.21.9",
+				"@babel/types": "^7.21.5"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.5.tgz",
-			"integrity": "sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==",
+			"version": "7.22.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.4.tgz",
+			"integrity": "sha512-Tn1pDsjIcI+JcLKq1AVlZEr4226gpuAQTsLMorsYg9tuS/kG7nuwwJ4AB8jfQuEgb/COBwR/DqJxmoiYFu5/rQ==",
 			"requires": {
 				"@babel/code-frame": "^7.21.4",
-				"@babel/generator": "^7.21.5",
-				"@babel/helper-environment-visitor": "^7.21.5",
+				"@babel/generator": "^7.22.3",
+				"@babel/helper-environment-visitor": "^7.22.1",
 				"@babel/helper-function-name": "^7.21.0",
 				"@babel/helper-hoist-variables": "^7.18.6",
 				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.21.5",
-				"@babel/types": "^7.21.5",
+				"@babel/parser": "^7.22.4",
+				"@babel/types": "^7.22.4",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -15264,9 +15268,9 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.5.tgz",
-			"integrity": "sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==",
+			"version": "7.22.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.4.tgz",
+			"integrity": "sha512-Tx9x3UBHTTsMSW85WB2kphxYQVvrZ/t1FxD88IpSgIjiUJlCm9z+xWIDwyo1vffTwSqteqyznB8ZE9vYYk16zA==",
 			"requires": {
 				"@babel/helper-string-parser": "^7.21.5",
 				"@babel/helper-validator-identifier": "^7.19.1",
@@ -17199,9 +17203,9 @@
 			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
 		},
 		"@types/babel__core": {
-			"version": "7.20.0",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
-			"integrity": "sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==",
+			"version": "7.20.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
+			"integrity": "sha512-aACu/U/omhdk15O4Nfb+fHgH/z3QsfQzpnvRZhYhThms83ZnAOZz7zZAWO7mn2yyNQaA4xTO8GLK3uqFU4bYYw==",
 			"requires": {
 				"@babel/parser": "^7.20.7",
 				"@babel/types": "^7.20.7",
@@ -17228,11 +17232,11 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.18.5",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.5.tgz",
-			"integrity": "sha512-enCvTL8m/EHS/zIvJno9nE+ndYPh1/oNFzRYRmtUqJICG2VnCSBzMLW5VN2KCQU91f23tsNKR8v7VJJQMatl7Q==",
+			"version": "7.20.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.1.tgz",
+			"integrity": "sha512-MitHFXnhtgwsGZWtT68URpOvLN4EREih1u3QtQiN4VdAxWKRVvGCSvw/Qth0M0Qq3pJpnGOu5JaM/ydK7OGbqg==",
 			"requires": {
-				"@babel/types": "^7.3.0"
+				"@babel/types": "^7.20.7"
 			}
 		},
 		"@types/glob": {
@@ -17298,9 +17302,9 @@
 			"dev": true
 		},
 		"@types/prettier": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
-			"integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg=="
+			"version": "2.7.3",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+			"integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA=="
 		},
 		"@types/stack-utils": {
 			"version": "2.0.1",
@@ -17833,14 +17837,14 @@
 			"integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
 		},
 		"browserslist": {
-			"version": "4.21.5",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
-			"integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+			"version": "4.21.7",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.7.tgz",
+			"integrity": "sha512-BauCXrQ7I2ftSqd2mvKHGo85XR0u7Ru3C/Hxsy/0TkfCtjrmAbPdzLGasmoiBxplpDXlPvdjX9u7srIMfgasNA==",
 			"requires": {
-				"caniuse-lite": "^1.0.30001449",
-				"electron-to-chromium": "^1.4.284",
-				"node-releases": "^2.0.8",
-				"update-browserslist-db": "^1.0.10"
+				"caniuse-lite": "^1.0.30001489",
+				"electron-to-chromium": "^1.4.411",
+				"node-releases": "^2.0.12",
+				"update-browserslist-db": "^1.0.11"
 			}
 		},
 		"bser": {
@@ -17988,9 +17992,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001486",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
-			"integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg=="
+			"version": "1.0.30001492",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz",
+			"integrity": "sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw=="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -18946,9 +18950,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.390",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.390.tgz",
-			"integrity": "sha512-9h6KDGTynRfpM16U40uLSCxRO3diIKcXXI0mPChKls7sfkxOlCH1sgSJ14Rb00BFomQNHY/p67gaZSu5Mu8j6w=="
+			"version": "1.4.417",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.417.tgz",
+			"integrity": "sha512-8rY8HdCxuSVY8wku3i/eDac4g1b4cSbruzocenrqBlzqruAZYHjQCHIjC66dLR9DXhEHTojsC4EjhZ8KmzwXqA=="
 		},
 		"emittery": {
 			"version": "0.8.1",
@@ -22555,9 +22559,9 @@
 					}
 				},
 				"semver": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-					"integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+					"version": "7.5.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+					"integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
@@ -23879,9 +23883,9 @@
 			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
 		},
 		"node-releases": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
-			"integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
+			"integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ=="
 		},
 		"nopt": {
 			"version": "4.0.3",
@@ -24033,9 +24037,9 @@
 			"dev": true
 		},
 		"nwsapi": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.4.tgz",
-			"integrity": "sha512-NHj4rzRo0tQdijE9ZqAx6kYDcoRwYwSYzCA8MY3JzfxlrvEU0jhnhJT9BhqhJs7I/dKcrDm6TyulaRqZPIhN5g=="
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.5.tgz",
+			"integrity": "sha512-6xpotnECFy/og7tKSBVmUNft7J3jyXAka4XvG6AUhFWRz+Q/Ljus7znJAA3bxColfQLdS+XsjoodtJfCgeTEFQ=="
 		},
 		"oauth-sign": {
 			"version": "0.9.0",
@@ -25787,9 +25791,9 @@
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
 		},
 		"tar": {
-			"version": "6.1.14",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.14.tgz",
-			"integrity": "sha512-piERznXu0U7/pW7cdSn7hjqySIVTYT6F76icmFk7ptU7dDYlXTm5r9A6K04R2vU3olYgoKeo1Cg3eeu5nhftAw==",
+			"version": "6.1.15",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
+			"integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
 			"requires": {
 				"chownr": "^2.0.0",
 				"fs-minipass": "^2.0.0",

--- a/packages/binary-install-example/binary.js
+++ b/packages/binary-install-example/binary.js
@@ -70,7 +70,7 @@ const getBinary = () => {
   // the url for this binary is constructed from values in `package.json`
   // https://github.com/EverlastingBugstopper/binary-install/releases/download/v1.0.0/binary-install-example-v1.0.0-x86_64-apple-darwin.tar.gz
   const url = `${repository.url}/releases/download/rust_v${version}/${name}-v${version}-${platformMetadata.RUST_TARGET}.tar.gz`;
-  return new Binary(platformMetadata.BINARY_NAME, url, {
+  return new Binary(platformMetadata.BINARY_NAME, url, version, {
     installDirectory: join(__dirname, "node_modules", ".bin")
   });
 };

--- a/packages/binary-install/README.md
+++ b/packages/binary-install/README.md
@@ -26,7 +26,7 @@ You could create an `install.js` file that looks something like this:
 #!/usr/bin/env node
 
 const { Binary } = require("binary-install");
-let binary = new Binary('my-binary', 'https://example.com/binary/tar.gz')
+let binary = new Binary('my-binary', 'https://example.com/binary/tar.gz', 'v1.0.0')
 binary.install();
 ```
 
@@ -57,7 +57,7 @@ You need one more thing before your package is ready to distribute. Make a `run.
 #!/usr/bin/env node
 
 const { Binary } = require("binary-install");
-let binary = new Binary('my-binary', 'https://example.com/binary/tar.gz')
+let binary = new Binary('my-binary', 'https://example.com/binary/tar.gz', 'v1.0.0')
 binary.run();
 ```
 
@@ -86,7 +86,7 @@ Any arguments you pass to the `install()` method will be [used to configure Axio
 You may want to override the base installation directory. To do so, you can pass a third parameter to the `Binary` constructor to specify `installDirectory`, like so:
 
 ```javascript
-  return new Binary("my-binary", "https://example.com/my-binary/macos-arm/v1.0.0.tar.gz", {
+  return new Binary("my-binary", "https://example.com/my-binary/macos-arm/v1.0.0.tar.gz", "v1.0.0", {
     installDirectory: join(__dirname, ".my-custom-binary-location")
   });
 ```

--- a/packages/binary-install/README.md
+++ b/packages/binary-install/README.md
@@ -83,7 +83,7 @@ Any arguments you pass to the `install()` method will be [used to configure Axio
 
 #### Overriding the base install directory
 
-You may want to override the base installation directory. To do so, you can pass a third parameter to the `Binary` constructor to specify `installDirectory`, like so:
+You may want to override the base installation directory. To do so, you can pass a fourth parameter to the `Binary` constructor to specify `installDirectory`, like so:
 
 ```javascript
   return new Binary("my-binary", "https://example.com/my-binary/macos-arm/v1.0.0.tar.gz", "v1.0.0", {

--- a/packages/binary-install/index.js
+++ b/packages/binary-install/index.js
@@ -12,7 +12,7 @@ const error = msg => {
 };
 
 class Binary {
-  constructor(name, url, config) {
+  constructor(name, url, version, config) {
     let errors = [];
     if (typeof url !== "string") {
       errors.push("url must be a string");
@@ -27,9 +27,22 @@ class Binary {
       errors.push("name must be a string");
     }
 
+    if (version && typeof version !== "string") {
+      errors.push("version must be a string");
+    }
+
     if (!name) {
       errors.push("You must specify the name of your binary");
     }
+
+    if (!version) {
+      errors.push("You must specify the version of your binary");
+    }
+
+    if (config && config.installDirectory && typeof config.installDirectory !== "string") {
+      errors.push("config.installDirectory must be a string");
+    }
+
     if (errors.length > 0) {
       let errorMsg =
         "One or more of the parameters you passed to the Binary constructor are invalid:\n";
@@ -37,11 +50,12 @@ class Binary {
         errorMsg += error;
       });
       errorMsg +=
-        '\n\nCorrect usage: new Binary("my-binary", "https://example.com/binary/download.tar.gz")';
+        '\n\nCorrect usage: new Binary("my-binary", "https://example.com/binary/download.tar.gz", "v1.0.0")';
       error(errorMsg);
     }
     this.url = url;
     this.name = name;
+    this.version = version;
     this.installDirectory =
       config?.installDirectory || join(__dirname, "node_modules", ".bin");
 
@@ -49,7 +63,7 @@ class Binary {
       mkdirSync(this.installDirectory, { recursive: true });
     }
 
-    this.binaryPath = join(this.installDirectory, this.name);
+    this.binaryPath = join(this.installDirectory, `${this.name}-${this.version}`);
   }
 
   exists() {

--- a/packages/binary-install/index.js
+++ b/packages/binary-install/index.js
@@ -39,7 +39,11 @@ class Binary {
       errors.push("You must specify the version of your binary");
     }
 
-    if (config && config.installDirectory && typeof config.installDirectory !== "string") {
+    if (
+      config &&
+      config.installDirectory &&
+      typeof config.installDirectory !== "string"
+    ) {
       errors.push("config.installDirectory must be a string");
     }
 
@@ -63,7 +67,10 @@ class Binary {
       mkdirSync(this.installDirectory, { recursive: true });
     }
 
-    this.binaryPath = join(this.installDirectory, `${this.name}-${this.version}`);
+    this.binaryPath = join(
+      this.installDirectory,
+      `${this.name}-${this.version}`
+    );
   }
 
   exists() {


### PR DESCRIPTION
breaking change: requires passing a version to the `new Binary` constructor that will be included in the binary that is downloaded