### PR TITLE
Fix package not working with Yarn PnP

### DIFF
--- a/packages/binary-install/package.json
+++ b/packages/binary-install/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.0",
   "description": "Install binary applications via npm",
   "main": "./index.js",
+  "preferUnplugged": true,
   "engines": {
     "node": ">=10"
   },


### PR DESCRIPTION
As this package commits the [cardinal sin of writing into its own package directory](https://yarnpkg.com/advanced/rulebook#packages-should-never-write-inside-their-own-folder-outside-of-postinstall), and Yarn's whole imperative is to nuke bad patterns out of orbit, it doesn't work with Yarn PnP. Therefore, there are two options to get this working:

1. Modify the logic such that the package does not write to itself and binaries are written elsewhere.
2. `preferUnplugged: true` and let Yarn extract the package into a disgustingly mutable directory.

This PR implements the latter because it took me two seconds.

With this change, Yarn users using PnP should no longer have any issues using rover and should no longer need to run an unplug command manually to get it working. Tada.